### PR TITLE
Enhancements from openZIM devs

### DIFF
--- a/pywikiapi/Site.py
+++ b/pywikiapi/Site.py
@@ -55,14 +55,14 @@ class Site:
         self.tokens = {}
         self.no_ssl = False  # For non-ssl sites, might be needed to avoid HTTPS
         self._is_bot = None  # Will be set by the is_bot()
-        self.maxlag = 5  # See https://www.mediawiki.org/wiki/Manual:Maxlag_parameter
+        self.maxlag = 30  # See https://www.mediawiki.org/wiki/Manual:Maxlag_parameter
 
         # If request is bigger than this, use POST instead
         self.auto_post_min_size = 2000
 
         # Number of retries to do in case of the lag error.
         # 0 - don't retry. negative - infinite.
-        self.retry_on_lag_error = 10
+        self.retry_on_lag_error = 50
 
         # Number of retries to do in case of ConnectionError
         # 0 - don't retry. negative - infinite

--- a/pywikiapi/Site.py
+++ b/pywikiapi/Site.py
@@ -425,7 +425,11 @@ class Site:
 
         r = self.session.request(method, url, timeout=timeout, headers=headers, **request_kw)
         if not r.ok:
-            raise ApiError('Call failed', r)
+            try:
+                raise ApiError('Call failed', {"status_code": r.status_code, "json_body": r.json()})
+            except requests.exceptions.JSONDecodeError:
+                raise ApiError('Call failed', {"status_code": r.status_code, "text_body": r.text}) from None
+
         if self.logger.isEnabledFor(logging.DEBUG):
             message = f"Request: {r.request.url}\nResponse: {len(r.content):,} bytes"
             self.logger.debug(message, dict(


### PR DESCRIPTION
We have 4 changes pending in the pipe which might improve the situation for other users as well.

## Changes
- Added delay and retries for weak API servers
  - Some servers (wikiHow) are not happy with fast, numerous requests to the API and prevent this from happening by refusing connections. This would mostly happen on pagination requests which is not controllable outside pywikiapi
  - This adds two params on Site to enable and allow customization of circumvention mechanisms:
    - `retry_after_conn`: nb of seconds to wait before retrying after a ConnectionError
    - `pre_request_delay`: nb of seconds to wait before each individual request.
  - Using the latter should avoid seeing ConnectionError, leaving the former a safety net.
- Increased tolerance to mediawiki's maxlag
  - Update maxlag value from 5 to 30 secs, to match what we regularly encountered in the wild (more than 5 secs lag) 
  - Decrease retry_on_lag_error from 50 to 10 (it is already a lot of retries)
- Handle requests timeout - provide a default and allow user to specify the value
  - By default, Python requests does not have any timeout ; it means that if for some reason the server is not responding, the program will wait forever
  - We have added a default of 60 seconds
  - The setting can be customized in `Site()`
- Fix issue with ApiError when raised directly from requests, to properly grab response content
  - When the HTTP request fails (4xx/5xx return code), the ApiError raised contained the whole response as data, unfortunately this is not JSON serializable which prove to be a problem to have useful logs
  - We propose to set the status code + the body as data in ApiError, the body is first tried to be JSON, and if it fails it is set as text (we do not handle the situation where even text decoding fails, it is probably extremely rare and nothing can be done from gibberish bytes anyway)